### PR TITLE
Adding Support for TLS 1.2 Because Some Services Refuse to Enable TLS 1.3

### DIFF
--- a/Felsökning/HttpBase.cs
+++ b/Felsökning/HttpBase.cs
@@ -21,8 +21,9 @@ namespace Felsökning
         {
             var httpClientHandler = new HttpClientHandler()
             {
-                //SslProtocols.Tls13
-                SslProtocols = SslProtocols.Tls13
+                // Met Éireann and Ireland West currently don't support TLS 1.3,
+                // which should make them feel bad - because it gives me a sad. :(
+                SslProtocols = SslProtocols.Tls13 | SslProtocols.Tls12
             };
 
             HttpClient = new HttpClient(httpClientHandler)


### PR DESCRIPTION
This PR resolves an issue where dependent NuGet packages fail because the remote hosts still don't support TLS 1.3 - even though it's been around for quite a while. (See: [RFC-8446](https://datatracker.ietf.org/doc/html/rfc8446).)