### PR TITLE
Adding Checks for String Being Fully Upper or Fully Lower

### DIFF
--- a/.github/workflows/build-and-publish-to-nuget.yaml
+++ b/.github/workflows/build-and-publish-to-nuget.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: .NET Restore
         run: dotnet restore --verbosity=normal
       - name: .NET Build
-        run: dotnet build --no-restore --verbosity=normal
+        run: dotnet build --no-restore --verbosity=normal /p:Version=${{ github.event.release.tag_name }}
       - name: .NET Test
         run: dotnet test --no-restore --no-build --verbosity=normal --collect:"XPlat Code Coverage" --logger:trx --results-directory coverage
       - name: Copy Coverage To Predictable Location

--- a/Felsökning.Tests/StringExtensionsTests.cs
+++ b/Felsökning.Tests/StringExtensionsTests.cs
@@ -14,6 +14,68 @@ namespace Felsökning.Tests
         [DataRow("")]
         [DataRow(" ")]
         [DataRow(null)]
+        public void IsLower_ShouldFailForNullEmptyOrWhitespace(string sut)
+        {
+            var exception = Assert.ThrowsException<ArgumentNullException>(() => sut.IsLower());
+
+            exception.Should().BeOfType<ArgumentNullException>();
+            exception.Message.Should().Be("Value cannot be null. (Parameter 'value')");
+        }
+
+        [TestMethod]
+        public void IsLower_ShouldSucceed()
+        {
+            var firstSut = "tEsTiNg";
+
+            var firstResult = firstSut.IsLower();
+            firstResult.Should().BeFalse();
+
+            var secondSut = "testing";
+
+            var secondResult = secondSut.IsLower();
+            secondResult.Should().BeTrue();
+        }
+
+        [DataTestMethod]
+        [DataRow("")]
+        [DataRow(" ")]
+        [DataRow(null)]
+        public void IsUpper_ShouldFailForNullEmptyOrWhitespace(string sut)
+        {
+            var exception = Assert.ThrowsException<ArgumentNullException>(() => sut.IsUpper());
+
+            exception.Should().BeOfType<ArgumentNullException>();
+            exception.Message.Should().Be("Value cannot be null. (Parameter 'value')");
+        }
+
+        [TestMethod]
+        public void IsUpper_ShouldSucceed()
+        {
+            var firstSut = "TESTING";
+
+            var firstResult = firstSut.IsUpper();
+            firstResult.Should().BeTrue();
+
+            var secondSut = "testing";
+
+            var secondResult = secondSut.IsUpper();
+            secondResult.Should().BeFalse();
+
+            var thirdSut = "teSTing";
+
+            var thirdResult = thirdSut.IsUpper();
+            thirdResult.Should().BeFalse();
+
+            var fourthSut = "TEsting";
+
+            var fourthResult = fourthSut.IsUpper();
+            fourthResult.Should().BeFalse();
+        }
+
+        [DataTestMethod]
+        [DataRow("")]
+        [DataRow(" ")]
+        [DataRow(null)]
         public void GetPostnummerDetails_ShouldFailForNullOrEmpty(string sut)
         {
             var exception = Assert.ThrowsException<ArgumentNullException>(() => sut.GetPostnummerDetails());

--- a/Felsökning/StringExtensions.cs
+++ b/Felsökning/StringExtensions.cs
@@ -66,6 +66,68 @@ namespace Felsökning
         }
 
         /// <summary>
+        ///     Extends the <see cref="string"/> class to include validation if the given string is all upper case.
+        /// </summary>
+        /// <param name="value">The current string context.</param>
+        /// <returns>A <see cref="bool"/> indicating if the entire word is upper case.</returns>
+        public static bool IsUpper(this string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            bool isAllUpper = false;
+            foreach (var character in value)
+            {
+                var textInfo = CultureInfo.InvariantCulture.TextInfo;
+                var resultCharacter = textInfo.ToUpper(character);
+                if (character == resultCharacter)
+                {
+                    isAllUpper = true;
+                }
+                else
+                {
+                    isAllUpper = false;
+                    break;
+                }
+            }
+
+            return isAllUpper;
+        }
+
+        /// <summary>
+        ///     Extends the <see cref="string"/> class to include validation if the given string is all lower case.
+        /// </summary>
+        /// <param name="value">The current string context.</param>
+        /// <returns>A <see cref="bool"/> indicating if the entire word is lower case.</returns>
+        public static bool IsLower(this string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            bool isAllLower = false;
+            foreach (var character in value)
+            {
+                var textInfo = CultureInfo.InvariantCulture.TextInfo;
+                var resultCharacter = textInfo.ToLower(character);
+                if (character == resultCharacter)
+                {
+                    isAllLower = true;
+                }
+                else
+                {
+                    isAllLower = false;
+                    break;
+                }
+            }
+
+            return isAllLower;
+        }
+
+        /// <summary>
         ///     Extends the <see cref="string"/> class to include validation if the given string is a valid Swedish personnummer via the Luhn Algorithm.
         /// </summary>
         /// <param name="value">The current string value context.</param>


### PR DESCRIPTION
This PR adds `string.IsUpper()` and `string.IsLower()` checks, to assist with automated text processing - for example, processing [text from Gutenberg](https://www.gutenberg.org/cache/epub/19755/pg19755.txt).